### PR TITLE
重複しているプロパティを削除

### DIFF
--- a/scss/lib/_core.scss
+++ b/scss/lib/_core.scss
@@ -320,7 +320,6 @@ h1,h2,h3,h4,h5,h6 {
         border: none;
         white-space: pre-wrap;
         text-overflow: ellipsis;
-        font-size: 100%;
         line-height: 1.3;
         font-size: .8rem;
         padding: 10px;


### PR DESCRIPTION
https://github.com/hatena/Hatena-Blog-Theme-Boilerplate/issues/9

`font-size` プロパティが重複しているので片方を削除