### PR TITLE
引用ボタンが表示されたときにpタグのmarginに変化が起きないようにする

### DIFF
--- a/scss/lib/_core.scss
+++ b/scss/lib/_core.scss
@@ -304,10 +304,10 @@ h1,h2,h3,h4,h5,h6 {
         border: 1px solid $border;
         margin: 0 0 10px;
         padding: 20px;
-        p:first-child {
+        p:first-of-type {
             margin-top: 0;
         }
-        p:last-child {
+        p:last-of-type {
             margin-bottom: 0;
         }
     }


### PR DESCRIPTION
- 記事内の引用で、引用ボタンが表示された際に `p` タグの margin が意図せず変わらないようにした
  - ボタンの表示により `:last-child` ではなくなることが原因

<img width="643" alt="スクリーンショット 2022-11-07 18 54 02" src="https://user-images.githubusercontent.com/2049569/200280741-b56c9db9-db60-41be-adce-fd540b7de352.png">