### PR TITLE
globalheader-containerのスタイル指定は出来なくしたので項目から消す

### DIFF
--- a/scss/lib/_core.scss
+++ b/scss/lib/_core.scss
@@ -28,15 +28,6 @@ h1,h2,h3,h4,h5,h6 {
     }
 }
 
-/* ヘッダ（グローバルヘッダ）
-  グローバルヘッダの中はiframeですが、
-  #globalheader-container に背景色や文字色を指定することでiframeの中にも色が反映されます。
-*/
-#globalheader-container {
-    background-color: $text;
-    color: $background;
-}
-
 /* container */
 #container,
 #footer {


### PR DESCRIPTION
- `.globalheader-container`を指定してスタイルを変更できなくしているので、コメントと項目を削除する
- ユーザーのお問い合わせから
  - https://box.hatena.sh/blog/2024%2F6_%E3%82%B5%E3%83%9D%E3%81%9F%E3%82%93%E5%AF%BE%E5%BF%9C%E3%83%AD%E3%82%B0#666a41a0f16e7d0000a02b79
